### PR TITLE
src/editor.rs: Fix crash caused by insert_new_line()

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -368,7 +368,7 @@ impl<'a> Editor<'a> {
             (self.cursor.y + 1, new_chars)
         };
         self.rows.insert(position, Row::new(new_row_chars));
-        self.update_row(self.cursor.y, false);
+        self.update_row(position, false);
         self.update_screen_cols();
         self.cursor.y += 1;
         self.cursor.x = 0;


### PR DESCRIPTION
Reproduce:
0. Start kibi;
1. Insert some characters;
2. Move cursor to middle of these inserted characters, and press Enter;
3. Press Left arrow key;
4. Kibi crash.