### PR TITLE
Use Default for Editor

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ fn run(mut args: std::env::Args) -> Result<(), Error> {
     if args.len() > 2 {
         return Err(Error::TooManyArguments(args.len() - 1));
     }
-    Editor::new(&Config::load()?)?.run(args.nth(1))
+    Editor::new(Config::load()?)?.run(args.nth(1))
 }
 
 fn main() {


### PR DESCRIPTION
Deriving `Default` for `Editor` allows us to save 10 LOCs.

This is also helpful to prepare for the Windows 10 compatibility work (#9): `ws_changed_receiver` and `orig_termios` becomes optional.