### PR TITLE
Minor changes to fix pedantic clippy warnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -30,17 +30,17 @@ pub struct Config {
 impl Default for Config {
     /// Default configuration.
     fn default() -> Self {
-        let conf_dirs = vec![
-            Ok(String::from("/etc/kibi")),
-            env::var("XDG_CONFIG_HOME").map(|d| d + "/kibi"),
-            env::var("HOME").map(|d| d + "/.config/kibi"),
+        let conf_dirs = [
+            Some(String::from("/etc/kibi")),
+            env::var("XDG_CONFIG_HOME").map(|d| d + "/kibi").ok(),
+            env::var("HOME").map(|d| d + "/.config/kibi").ok(),
         ];
         Self {
             tab_stop: 4,
             quit_times: 2,
             message_duration: Duration::from_secs(3),
             show_line_num: true,
-            conf_dirs: conf_dirs.into_iter().filter_map(Result::ok).map(PathBuf::from).collect(),
+            conf_dirs: conf_dirs.iter().filter_map(|d| d.as_ref().map(PathBuf::from)).collect(),
         }
     }
 }
@@ -56,7 +56,7 @@ impl Config {
     ///
     /// Will return `Err` if one of the configuration file cannot be parsed properly.
     pub fn load() -> Result<Self, Error> {
-        let mut conf: Config = Default::default();
+        let mut conf = Self::default();
 
         let conf_paths: Vec<PathBuf> =
             conf.conf_dirs.iter().map(|p| p.join("config.ini")).filter(|p| p.exists()).collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 //! # Kibi
 
-use kibi::{ansi_escape::*, Config, Editor, Error};
+use kibi::{ansi_escape::CLEAR_SCREEN, ansi_escape::MOVE_CURSOR_TO_START, Config, Editor, Error};
 
 /// Load the configuration, initialize the editor and run the program, optionally opening a file if
 /// an argument is given.

--- a/src/row.rs
+++ b/src/row.rs
@@ -5,7 +5,7 @@
 
 use std::iter::repeat;
 
-use crate::ansi_escape::*;
+use crate::ansi_escape::{RESET_FMT, REVERSE_VIDEO};
 use crate::syntax::{HLType, SyntaxConf};
 use unicode_width::UnicodeWidthChar;
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -3,7 +3,7 @@ use std::io::{self, BufRead, Read, Write};
 use libc::{STDIN_FILENO, STDOUT_FILENO, TIOCGWINSZ, VMIN, VTIME};
 use nix::{pty::Winsize, sys::termios};
 
-use crate::{ansi_escape::*, Error};
+use crate::{ansi_escape::DEVICE_STATUS_REPORT, ansi_escape::REPOSITION_CURSOR_END, Error};
 
 pub(crate) fn set_termios(term: &termios::Termios) -> Result<(), nix::Error> {
     termios::tcsetattr(STDIN_FILENO, termios::SetArg::TCSAFLUSH, term)


### PR DESCRIPTION
Fix the following pedantic/nursery clippy warnings:
- [called `filter_map(p).map(q)` on an `Iterator`](https://rust-lang.github.io/rust-clippy/master/index.html#filter_map)
- [unnecessary structure name repetition](https://rust-lang.github.io/rust-clippy/master/index.html#use_self)
- [calling `config::Config::default()` is more clear than this expression](https://rust-lang.github.io/rust-clippy/master/index.html#default_trait_access)
- [usage of wildcard import](https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_imports) (partial fix)