### PR TITLE
Implement native method to obtain the window size on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
  "same-file",
  "thread_local",
  "walkdir",
- "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util",
 ]
 
 [[package]]
@@ -478,7 +478,7 @@ dependencies = [
  "tokei",
  "unicode-width",
  "winapi 0.3.8",
- "winapi-util 0.1.3 (git+https://github.com/ilai-deutel/winapi-util?branch=sr-window)",
+ "winapi-util",
 ]
 
 [[package]]
@@ -757,7 +757,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
- "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util",
 ]
 
 [[package]]
@@ -869,7 +869,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 dependencies = [
- "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util",
 ]
 
 [[package]]
@@ -969,7 +969,7 @@ checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 dependencies = [
  "same-file",
  "winapi 0.3.8",
- "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1008,17 +1008,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.3"
-source = "git+https://github.com/ilai-deutel/winapi-util?branch=sr-window#05a7052e187891c33e432ad26e9ece7aa4f06b3e"
-dependencies = [
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80"
+checksum = "fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e"
 dependencies = [
  "winapi 0.3.8",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ dependencies = [
  "same-file",
  "thread_local",
  "walkdir",
- "winapi-util",
+ "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -476,7 +476,7 @@ dependencies = [
  "tokei",
  "unicode-width",
  "winapi 0.3.8",
- "winapi-util",
+ "winapi-util 0.1.3 (git+https://github.com/ilai-deutel/winapi-util?branch=sr-window)",
 ]
 
 [[package]]
@@ -764,7 +764,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
- "winapi-util",
+ "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -891,7 +891,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 dependencies = [
- "winapi-util",
+ "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -991,7 +991,7 @@ checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 dependencies = [
  "same-file",
  "winapi 0.3.8",
- "winapi-util",
+ "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1027,6 +1027,14 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.3"
+source = "git+https://github.com/ilai-deutel/winapi-util?branch=sr-window#d9b74f1efd1a767c6c00059a7a9ed61ca41e452a"
+dependencies = [
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "winapi-util"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
+checksum = "d663a8e9a99154b5fb793032533f6328da35e23aac63d5c152279aa8ba356825"
 
 [[package]]
 name = "arrayref"
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "base64"
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502ae1441a0a5adb8fbd38a5955a6416b9493e92b465de5e4a9bde6a539c2c48"
+checksum = "2889e6d50f394968c8bf4240dc3f2a7eb4680844d27308f798229ac9d4725f41"
 dependencies = [
  "memchr",
 ]
@@ -207,24 +207,26 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
+ "maybe-uninit",
  "memoffset",
  "scopeguard",
 ]
@@ -241,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -364,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "globset"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2"
+checksum = "7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -377,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "grep-matcher"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c2fa3a90e22690d6921196acf1e0c1aa5840b2defc0b9549392f35ba537484"
+checksum = "fdf0e1fd5af17008a918fd868e63ec0226e96ce88b832f00c7fb041e014b9350"
 dependencies = [
  "memchr",
 ]
@@ -415,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.6"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
+checksum = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
 dependencies = [
  "libc",
 ]
@@ -433,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d692f1fdb7a67fad17cb4d3dbe3fc9c4d50d3113349251678db987b225ccabba"
+checksum = "ddf60d063dbe6b75388eec66cfc07781167ae3d34a09e0c433e6c5de0511f7fb"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
@@ -523,9 +525,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.3.0"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memmap"
@@ -539,11 +541,11 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
+checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
 dependencies = [
- "rustc_version",
+ "autocfg",
 ]
 
 [[package]]
@@ -601,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4fb201c5c22a55d8b24fef95f78be52738e5e1361129be1b5e862ecdb6894a"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
 ]
@@ -620,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9fcf299b5712d06ee128a556c94709aaa04512c4dffb8ead07c5c998447fc0"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
@@ -633,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df43fd99896fd72c485fe47542c7b500e4ac1e8700bf995544d1317a60ded547"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
 dependencies = [
  "maplit",
  "pest",
@@ -650,9 +652,9 @@ checksum = "fcfdefadc3d57ca21cf17990a28ef4c0f7c61383a28cb7604cf4a18e6ede1420"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
+checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
 dependencies = [
  "unicode-xid",
 ]
@@ -665,9 +667,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
  "proc-macro2",
 ]
@@ -715,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.4"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
+checksum = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -727,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.14"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
+checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 
 [[package]]
 name = "rust-argon2"
@@ -744,19 +746,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "ryu"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
+checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
 
 [[package]]
 name = "same-file"
@@ -769,24 +762,9 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -810,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.47"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15913895b61e0be854afd32fd4163fcd2a3df34142cf2cb961b310ce694cbf90"
+checksum = "78a7a12c167809363ec3bd7329fc0a3369056996de43c4b37ef3cd54a6ce4867"
 dependencies = [
  "itoa",
  "ryu",
@@ -865,9 +843,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
+checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -955,9 +933,9 @@ checksum = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f00ed7be0c1ff1e24f46c3d2af4859f7e863672ba3a6e92e7cff702bf9f06c2"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-width"
@@ -1031,7 +1009,7 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 [[package]]
 name = "winapi-util"
 version = "0.1.3"
-source = "git+https://github.com/ilai-deutel/winapi-util?branch=sr-window#d9b74f1efd1a767c6c00059a7a9ed61ca41e452a"
+source = "git+https://github.com/ilai-deutel/winapi-util?branch=sr-window#05a7052e187891c33e432ad26e9ece7aa4f06b3e"
 dependencies = [
  "winapi 0.3.8",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ signal-hook = "0.1.13"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.8", default-features = false, features = ["wincon"] }
-winapi-util = "0.1.3"
+winapi-util = { git = "https://github.com/ilai-deutel/winapi-util", branch = "sr-window" }
 
 [dev-dependencies]
 tokei = "11.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ signal-hook = "0.1.13"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.8", default-features = false, features = ["wincon"] }
-winapi-util = { git = "https://github.com/ilai-deutel/winapi-util", branch = "sr-window" }
+winapi-util = "0.1.4"
 
 [dev-dependencies]
 tokei = "11.0.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ pub enum Error {
     IO(std::io::Error),
     #[cfg(unix)]
     Nix(nix::Error),
+    InvalidWindowSize,
     MPSCTryRecv(std::sync::mpsc::TryRecvError),
     CursorPosition,
     Config(String, String),
@@ -20,6 +21,7 @@ impl Debug for Error {
             Self::IO(err) => write!(f, "IO error: {}", err),
             #[cfg(unix)]
             Self::Nix(err) => write!(f, "System call error: {}", err),
+            Self::InvalidWindowSize => write!(f, "Invalid window size"),
             Self::MPSCTryRecv(err) => write!(f, "MSPC try_recv error: {}", err),
             Self::CursorPosition => write!(f, "Could not obtain cursor position"),
             Self::Config(line, reason) => write!(f, "Could not parse config {}: {}", line, reason),

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -7,6 +7,8 @@ use crate::{ansi_escape::DEVICE_STATUS_REPORT, ansi_escape::REPOSITION_CURSOR_EN
 /// This function moves the cursor to the bottom-right using ANSI escape sequence
 /// `\x1b[999C\x1b[999B`, then requests the cursor position using ANSI escape sequence `\x1b[6n`.
 /// After this sequence is sent, the next characters on stdin should be `\x1b[{row};{column}R`.
+///
+/// It is used as an alternative method if `sys::get_window_size()` returns an error.
 pub(crate) fn get_window_size_using_cursor() -> Result<(usize, usize), Error> {
     print!("{}{}", REPOSITION_CURSOR_END, DEVICE_STATUS_REPORT);
     io::stdout().flush()?;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -2,11 +2,12 @@
 //!
 //! Windows-specific structs and functions. Will be imported as `sys` on Windows systems.
 
-use std::sync::mpsc::Receiver;
+use std::{io, sync::mpsc::Receiver};
 
 use winapi::um::wincon::*;
+use winapi_util::{console, HandleRef};
 
-pub(crate) use crate::{terminal::get_window_size_using_cursor as get_window_size, Error};
+use crate::Error;
 
 // On Windows systems, the terminal mode is represented as an unsigned int.
 pub(crate) type TermMode = u32;
@@ -14,19 +15,24 @@ pub(crate) type TermMode = u32;
 /// Return configuration directories for Windows systems
 pub(crate) fn conf_dirs() -> [Option<String>; 1] { [std::env::var("APPDATA").ok()] }
 
+pub(crate) fn get_window_size() -> Result<(usize, usize), Error> {
+    let w_rect = console::screen_buffer_info(HandleRef::stdout())?.window_rect();
+    Ok(((w_rect.Bottom - w_rect.Top + 1) as usize, (w_rect.Right - w_rect.Left + 1) as usize))
+}
+
 pub(crate) fn get_window_size_update_receiver() -> Result<Option<Receiver<()>>, Error> { Ok(None) }
 
 /// Set the terminal mode.
-pub(crate) fn set_term_mode(stdin_term_mode: &TermMode) -> Result<(), std::io::Error> {
-    winapi_util::console::set_mode(winapi_util::HandleRef::stdin(), *stdin_term_mode)
+pub(crate) fn set_term_mode(stdin_term_mode: &TermMode) -> Result<(), io::Error> {
+    console::set_mode(HandleRef::stdin(), *stdin_term_mode)
 }
 
 /// Enable raw mode, and return the original terminal mode.
 ///
 /// Documentation for console modes is available at:
-/// <https://docs.microsoft.com/en-us/windows/console/setconsolemodel>
+/// <https://docs.microsoft.com/en-us/windows/console/setconsolemode>
 pub(crate) fn enable_raw_mode() -> Result<TermMode, Error> {
-    let orig_mode_in = winapi_util::console::mode(winapi_util::HandleRef::stdin())?;
+    let orig_mode_in = console::mode(HandleRef::stdin())?;
     let mode_in = (orig_mode_in | ENABLE_VIRTUAL_TERMINAL_INPUT)
         & !(ENABLE_PROCESSED_INPUT | ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT);
     set_term_mode(&mode_in)?;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -18,7 +18,7 @@ pub(crate) fn conf_dirs() -> [Option<String>; 1] { [std::env::var("APPDATA").ok(
 /// Return the current window size as (rows, columns).
 pub(crate) fn get_window_size() -> Result<(usize, usize), Error> {
     let w_rect = console::screen_buffer_info(HandleRef::stdout())?.window_rect();
-    Ok(((w_rect.Bottom - w_rect.Top + 1) as usize, (w_rect.Right - w_rect.Left + 1) as usize))
+    Ok(((w_rect.bottom - w_rect.top + 1) as usize, (w_rect.right - w_rect.left + 1) as usize))
 }
 
 pub(crate) fn get_window_size_update_receiver() -> Result<Option<Receiver<()>>, Error> { Ok(None) }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -15,6 +15,7 @@ pub(crate) type TermMode = u32;
 /// Return configuration directories for Windows systems
 pub(crate) fn conf_dirs() -> [Option<String>; 1] { [std::env::var("APPDATA").ok()] }
 
+/// Return the current window size as (rows, columns).
 pub(crate) fn get_window_size() -> Result<(usize, usize), Error> {
     let w_rect = console::screen_buffer_info(HandleRef::stdout())?.window_rect();
     Ok(((w_rect.Bottom - w_rect.Top + 1) as usize, (w_rect.Right - w_rect.Left + 1) as usize))


### PR DESCRIPTION
Use `GetConsoleScreenBufferInfo` to obtain the window size; fall back to the ANSI escape sequence based method if the native method fails.