### PR TITLE
Fix clippy lints redundant_pub_crate, module_name_repetitions + lints for Windows

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -12,14 +12,14 @@ use crate::{sys::conf_dirs as cdirs, Error, Error::Config as ConfErr};
 #[derive(Debug, PartialEq)]
 pub struct Config {
     /// The size of a tab. Must be > 0.
-    pub(crate) tab_stop: usize,
+    pub tab_stop: usize,
     /// The number of confirmations needed before quitting, when changes have been made since the
     /// file was last changed.
-    pub(crate) quit_times: usize,
+    pub quit_times: usize,
     /// The duration for which messages are shown in the status bar.
-    pub(crate) message_dur: Duration,
+    pub message_dur: Duration,
     /// Whether to display line numbers.
-    pub(crate) show_line_num: bool,
+    pub show_line_num: bool,
 }
 
 impl Default for Config {
@@ -72,7 +72,7 @@ impl Config {
 ///
 /// The `kv_fn` function will be called for each key-value pair in the file. Typically, this
 /// function will update a configuration instance.
-pub(crate) fn process_ini_file<F>(path: &Path, kv_fn: &mut F) -> Result<(), Error>
+pub fn process_ini_file<F>(path: &Path, kv_fn: &mut F) -> Result<(), Error>
 where F: FnMut(&str, &str) -> Result<(), String> {
     for (i, line) in BufReader::new(File::open(path)?).lines().enumerate() {
         let (i, line) = (i + 1, line?);
@@ -88,13 +88,13 @@ where F: FnMut(&str, &str) -> Result<(), String> {
 }
 
 /// Trim a value (right-hand side of a key=value INI line) and parses it.
-pub(crate) fn parse_value<T: FromStr<Err = E>, E: Display>(value: &str) -> Result<T, String> {
+pub fn parse_value<T: FromStr<Err = E>, E: Display>(value: &str) -> Result<T, String> {
     value.trim().parse().map_err(|e| format!("Parser error: {}", e))
 }
 
 /// Split a comma-separated list of values (right-hand side of a key=value1,value2,... INI line) and
 /// parse it as a Vec.
-pub(crate) fn parse_values<T: FromStr<Err = E>, E: Display>(value: &str) -> Result<Vec<T>, String> {
+pub fn parse_values<T: FromStr<Err = E>, E: Display>(value: &str) -> Result<Vec<T>, String> {
     value.split(',').map(parse_value).collect()
 }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -6,7 +6,7 @@ use std::sync::mpsc::{Receiver, TryRecvError};
 use std::{fmt::Display, fs::File, path::Path, thread, time::Instant};
 
 use crate::row::{HLState, Row};
-use crate::{ansi_escape::*, syntax::SyntaxConf, sys, terminal, Config, Error};
+use crate::{ansi_escape::*, syntax::Conf as SyntaxConf, sys, terminal, Config, Error};
 
 const fn ctrl_key(key: u8) -> u8 { key & 0x1f }
 const EXIT: u8 = ctrl_key(b'Q');

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -10,7 +10,7 @@ use crate::{sys, Error};
 /// to the discriminant, modulo 100. The colors are described here:
 /// <https://en.wikipedia.org/wiki/ANSI_escape_code#Colors>
 #[derive(PartialEq, Copy, Clone)]
-pub(crate) enum HLType {
+pub enum HLType {
     Normal = 39,     // Default foreground color
     Number = 31,     // Red
     Match = 46,      // Cyan
@@ -29,28 +29,28 @@ impl Display for HLType {
 
 /// Configuration for syntax highlighting.
 #[derive(Clone, Default)]
-pub(crate) struct SyntaxConf {
+pub struct Conf {
     /// The name of the language, e.g. "Rust".
-    pub(crate) name: String,
+    pub name: String,
     /// Whether to highlight numbers.
-    pub(crate) highlight_numbers: bool,
+    pub highlight_numbers: bool,
     /// Whether to highlight single-line strings.
-    pub(crate) hightlight_sl_strings: bool,
+    pub hightlight_sl_strings: bool,
     /// The tokens that starts a single-line comment, e.g. "//".
-    pub(crate) sl_comment_start: Vec<String>,
+    pub sl_comment_start: Vec<String>,
     /// The tokens that start and end a multi-line comment, e.g. ("/*", "*/").
-    pub(crate) ml_comment_delims: Option<(String, String)>,
+    pub ml_comment_delims: Option<(String, String)>,
     /// The token that start and end a multi-line strings, e.g. "\"\"\"" for Python.
-    pub(crate) ml_string_delim: Option<String>,
+    pub ml_string_delim: Option<String>,
     /// Keywords to highlight and there corresponding HLType (typically
     /// HLType::Keyword1 or HLType::Keyword2)
-    pub(crate) keywords: Vec<(HLType, Vec<String>)>,
+    pub keywords: Vec<(HLType, Vec<String>)>,
 }
 
-impl SyntaxConf {
+impl Conf {
     /// Return the syntax configuration corresponding to the given file extension, if a matching
     /// INI file is found in a config directory.
-    pub(crate) fn get(ext: &str) -> Result<Option<Self>, Error> {
+    pub fn get(ext: &str) -> Result<Option<Self>, Error> {
         for conf_dir in sys::data_dirs() {
             match PathBuf::from(conf_dir).join("syntax.d").read_dir() {
                 Ok(dir_entries) =>

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -9,7 +9,7 @@ use crate::{ansi_escape::DEVICE_STATUS_REPORT, ansi_escape::REPOSITION_CURSOR_EN
 /// After this sequence is sent, the next characters on stdin should be `\x1b[{row};{column}R`.
 ///
 /// It is used as an alternative method if `sys::get_window_size()` returns an error.
-pub(crate) fn get_window_size_using_cursor() -> Result<(usize, usize), Error> {
+pub fn get_window_size_using_cursor() -> Result<(usize, usize), Error> {
     print!("{}{}", REPOSITION_CURSOR_END, DEVICE_STATUS_REPORT);
     io::stdout().flush()?;
     let mut prefix_buffer = [0_u8; 2];

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -10,7 +10,7 @@ use nix::{pty::Winsize, sys::termios};
 use signal_hook::{iterator::Signals, SIGWINCH};
 
 // On UNIX systems, Termios represents the terminal mode.
-pub(crate) use nix::sys::termios::Termios as TermMode;
+pub use nix::sys::termios::Termios as TermMode;
 
 use crate::Error;
 
@@ -39,10 +39,10 @@ fn xdg_dirs(xdg_type: &str, def_home_suffix: &str, def_dirs: &str) -> Vec<String
 }
 
 /// Return configuration directories for UNIX systems
-pub(crate) fn conf_dirs() -> Vec<String> { xdg_dirs("CONFIG", "/.config", "/etc/xdg:/etc") }
+pub fn conf_dirs() -> Vec<String> { xdg_dirs("CONFIG", "/.config", "/etc/xdg:/etc") }
 
 /// Return syntax directories for UNIX systems
-pub(crate) fn data_dirs() -> Vec<String> {
+pub fn data_dirs() -> Vec<String> {
     xdg_dirs("DATA", "/.local/share", "/usr/local/share/:/usr/share/")
 }
 
@@ -51,7 +51,7 @@ pub(crate) fn data_dirs() -> Vec<String> {
 /// We use the `TIOCGWINSZ` ioctl to get window size. If it succeeds, a `Winsize` struct will be
 /// populated.
 /// This ioctl is described here: <http://man7.org/linux/man-pages/man4/tty_ioctl.4.html>
-pub(crate) fn get_window_size() -> Result<(usize, usize), Error> {
+pub fn get_window_size() -> Result<(usize, usize), Error> {
     nix::ioctl_read_bad!(get_ws, TIOCGWINSZ, Winsize);
 
     let mut maybe_ws = std::mem::MaybeUninit::<Winsize>::uninit();
@@ -62,7 +62,7 @@ pub(crate) fn get_window_size() -> Result<(usize, usize), Error> {
 }
 
 /// Return a MPSC receiver that receives a message whenever the window size is updated.
-pub(crate) fn get_window_size_update_receiver() -> Result<Option<Receiver<()>>, Error> {
+pub fn get_window_size_update_receiver() -> Result<Option<Receiver<()>>, Error> {
     // Create a channel for receiving window size update requests
     let (ws_changed_tx, ws_changed_rx) = mpsc::sync_channel(1);
     // Spawn a new thread that will push to the aforementioned channel every time the SIGWINCH
@@ -73,14 +73,14 @@ pub(crate) fn get_window_size_update_receiver() -> Result<Option<Receiver<()>>, 
 }
 
 /// Set the terminal mode.
-pub(crate) fn set_term_mode(term: &TermMode) -> Result<(), nix::Error> {
+pub fn set_term_mode(term: &TermMode) -> Result<(), nix::Error> {
     termios::tcsetattr(STDIN_FILENO, termios::SetArg::TCSAFLUSH, term)
 }
 
 /// Setup the termios to enable raw mode, and return the original termios.
 ///
 /// termios manual is available at: <http://man7.org/linux/man-pages/man3/termios.3.html>
-pub(crate) fn enable_raw_mode() -> Result<TermMode, Error> {
+pub fn enable_raw_mode() -> Result<TermMode, Error> {
     let orig_termios = termios::tcgetattr(STDIN_FILENO)?;
     let mut term = orig_termios.clone();
     termios::cfmakeraw(&mut term);

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -11,27 +11,25 @@ use crate::Error;
 
 // On Windows systems, the terminal mode is represented as 2 unsigned integers (one for stdin, one
 // for stdout).
-pub(crate) type TermMode = (u32, u32);
+pub type TermMode = (u32, u32);
 
 /// Return configuration directories for Windows systems
-pub(crate) fn conf_dirs() -> Vec<String> {
-    var("APPDATA").map(|d| d + "/Kibi").into_iter().collect()
-}
+pub fn conf_dirs() -> Vec<String> { var("APPDATA").map(|d| d + "/Kibi").into_iter().collect() }
 
 /// Return data directories for Windows systems
-pub(crate) fn data_dirs() -> Vec<String> { conf_dirs() }
+pub fn data_dirs() -> Vec<String> { conf_dirs() }
 
 /// Return the current window size as (rows, columns).
-pub(crate) fn get_window_size() -> Result<(usize, usize), Error> {
+pub fn get_window_size() -> Result<(usize, usize), Error> {
     let w_rect = cons::screen_buffer_info(HandleRef::stdout())?.window_rect();
     Ok(((w_rect.bottom - w_rect.top + 1) as usize, (w_rect.right - w_rect.left + 1) as usize))
 }
 
-pub(crate) fn get_window_size_update_receiver() -> Result<Option<Receiver<()>>, Error> { Ok(None) }
+pub fn get_window_size_update_receiver() -> Result<Option<Receiver<()>>, Error> { Ok(None) }
 
 /// Set the terminal mode.
 #[allow(clippy::trivially_copy_pass_by_ref)]
-pub(crate) fn set_term_mode((stdin_mode, stdout_mode): &TermMode) -> Result<(), io::Error> {
+pub fn set_term_mode((stdin_mode, stdout_mode): &TermMode) -> Result<(), io::Error> {
     cons::set_mode(HandleRef::stdin(), *stdin_mode)?;
     cons::set_mode(HandleRef::stdout(), *stdout_mode)
 }
@@ -40,7 +38,7 @@ pub(crate) fn set_term_mode((stdin_mode, stdout_mode): &TermMode) -> Result<(), 
 ///
 /// Documentation for console modes is available at:
 /// <https://docs.microsoft.com/en-us/windows/console/setconsolemode>
-pub(crate) fn enable_raw_mode() -> Result<TermMode, Error> {
+pub fn enable_raw_mode() -> Result<TermMode, Error> {
     // (mode_in0, mode_out0) are the original terminal modes
     let (mode_in0, mode_out0) = (cons::mode(HandleRef::stdin())?, cons::mode(HandleRef::stdout())?);
 


### PR DESCRIPTION
Fix the following clippy lints:
- [`redundant_pub_crate`](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pub_crate) (nursery)
- [`module_name_repetitions`](https://rust-lang.github.io/rust-clippy/master/index.html#module_name_repetitions) (pedantic)
- [`cast_sign_loss`](https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss) (pedantic)
- [`wildcard_imports`](https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_imports) (pedantic)

All current pedantic and nursery lints should pass.