### PR TITLE
Add syntax config for single line string quotes; JSON syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Syntax highlighting can be configured using INI files which follow this format:
 name=Rust
 extensions=rs
 highlight_numbers=true
-highlight_strings=true
+singleline_string_quotes=", '
 singleline_comment_start=//
 multiline_comment_delims=/*, */
 ; In Rust, the multi-line string delimiter is the same as the single-line string delimiter

--- a/src/row.rs
+++ b/src/row.rs
@@ -133,21 +133,18 @@ impl Row {
             let c = line[i];
 
             // At this point, hl_state is Normal or String
-
-            if syntax.hightlight_sl_strings {
-                if let HLState::String(quote) = hl_state {
+            if let HLState::String(quote) = hl_state {
+                self.hl.push(HLType::String);
+                if c == quote {
+                    hl_state = HLState::Normal;
+                } else if c == b'\\' && i != line.len() - 1 {
                     self.hl.push(HLType::String);
-                    if c == quote {
-                        hl_state = HLState::Normal;
-                    } else if c == b'\\' && i != line.len() - 1 {
-                        self.hl.push(HLType::String);
-                    }
-                    continue;
-                } else if c == b'"' || c == b'\'' {
-                    hl_state = HLState::String(c);
-                    self.hl.push(HLType::String);
-                    continue;
                 }
+                continue;
+            } else if syntax.sl_string_quotes.contains(&(c as char)) {
+                hl_state = HLState::String(c);
+                self.hl.push(HLType::String);
+                continue;
             }
 
             let prev_sep = (i == 0) || is_sep(line[i - 1]);

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -34,8 +34,8 @@ pub struct Conf {
     pub name: String,
     /// Whether to highlight numbers.
     pub highlight_numbers: bool,
-    /// Whether to highlight single-line strings.
-    pub hightlight_sl_strings: bool,
+    /// Quotes for single-line strings.
+    pub sl_string_quotes: Vec<char>,
     /// The tokens that starts a single-line comment, e.g. "//".
     pub sl_comment_start: Vec<String>,
     /// The tokens that start and end a multi-line comment, e.g. ("/*", "*/").
@@ -74,7 +74,7 @@ impl Conf {
                 "name" => sc.name = pv(val)?,
                 "extensions" => extensions.extend(val.split(',').map(|u| String::from(u.trim()))),
                 "highlight_numbers" => sc.highlight_numbers = pv(val)?,
-                "highlight_strings" => sc.hightlight_sl_strings = pv(val)?,
+                "singleline_string_quotes" => sc.sl_string_quotes = pvs(val)?,
                 "singleline_comment_start" => sc.sl_comment_start = pvs(val)?,
                 "multiline_comment_delims" =>
                     sc.ml_comment_delims = match &val.split(',').collect::<Vec<_>>()[..] {
@@ -89,5 +89,27 @@ impl Conf {
             Ok(())
         })?;
         Ok((sc, extensions))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn syntax_d_files() {
+        let mut file_count = 0;
+        let mut syntax_names = HashSet::new();
+        for path in fs::read_dir("./syntax.d").unwrap() {
+            let (conf, extensions) = Conf::from_file(&path.unwrap().path()).unwrap();
+            assert!(!extensions.is_empty());
+            syntax_names.insert(conf.name);
+            file_count += 1;
+        }
+        assert!(file_count > 0);
+        assert_eq!(file_count, syntax_names.len());
     }
 }

--- a/syntax.d/bash.ini
+++ b/syntax.d/bash.ini
@@ -1,7 +1,7 @@
 name=Bash
 extensions=bash, sh
 singleline_comment_start=#
-highlight_strings=true
+singleline_string_quotes=", '
 # https://www.gnu.org/software/bash/manual/html_node/Bourne-Shell-Builtins.html
 keywords_1=:, ., break, cd, continue, eval, exec, exit, export, getopts, hash, pwd, readonly, return, shift, test, [, times, trap, umask, unset
 # https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html

--- a/syntax.d/json.ini
+++ b/syntax.d/json.ini
@@ -1,0 +1,5 @@
+name=json
+extensions=json
+highlight_numbers=true
+singleline_string_quotes="
+keywords_1=true,false,null

--- a/syntax.d/python.ini
+++ b/syntax.d/python.ini
@@ -1,7 +1,7 @@
 name=Python
 extensions=py, pyi
 highlight_numbers=true
-highlight_strings=true
+singleline_string_quotes=", '
 singleline_comment_start=#
 multiline_string_delim="""
 ; https://github.com/python/cpython/blob/3.8/Lib/keyword.py

--- a/syntax.d/rust.ini
+++ b/syntax.d/rust.ini
@@ -1,7 +1,7 @@
 name=Rust
 extensions=rs
 highlight_numbers=true
-highlight_strings=true
+singleline_string_quotes=", '
 singleline_comment_start=//
 multiline_comment_delims=/*, */
 ; In Rust, the multi-line string delimiter is the same as the single-line string delimiter

--- a/syntax.d/toml.ini
+++ b/syntax.d/toml.ini
@@ -1,7 +1,7 @@
 name=TOML
 extensions=toml
 highlight_numbers=true
-highlight_strings=true
+singleline_string_quotes=", '
 singleline_comment_start=#
 multiline_string_delim="""
 keywords_1=true, false


### PR DESCRIPTION
- Add syntax configuration for single line string quotes (e.g. `"` for JSON, `"` and `'` for Rust)
- Add syntax configuration file for JSON
- Add test for files in `syntax.d`