### PR TITLE
Editor: Remove unnecessary wraps and ignore Clippy false positve

### DIFF
--- a/count_loc.sh
+++ b/count_loc.sh
@@ -23,7 +23,7 @@ for path in "${paths[@]}"; do
 
   tempfile=$(mktemp --suffix .rs)
   # Ignore Clippy directives
-  code=$(grep -v -P '^\s*#!\[(?:allow|warn|deny)\(clippy::' "$path")
+  code=$(grep -v -P '^\s*#!?\[(?:allow|warn|deny)\(clippy::' "$path")
   # Ignore everything after #[cfg(test)]
   echo "${code%'#[cfg(test)]'*}" > "$tempfile"
   file_loc=$(tokei "$tempfile" -t=Rust -o json | jq .Rust.code)


### PR DESCRIPTION
Fix nightly Clippy warnings (https://travis-ci.com/github/ilai-deutel/kibi/jobs/455252067):
* False negative for `field-reassign-with-default`
* `unnecessary-wraps` for `process_keypress` 