### PR TITLE
Fix upper_case_acronyms clippy warnings

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -4,7 +4,7 @@ use std::io::{self, BufRead, BufReader, ErrorKind::NotFound, Read, Seek, Write};
 use std::iter::{self, repeat, successors};
 use std::{fmt::Display, fs::File, path::Path, process::Command, thread, time::Instant};
 
-use crate::row::{HLState, Row};
+use crate::row::{HlState, Row};
 use crate::{ansi_escape::*, syntax::Conf as SyntaxConf, sys, terminal, Config, Error};
 
 const fn ctrl_key(key: u8) -> u8 { key & 0x1f }
@@ -301,7 +301,7 @@ impl Editor {
     /// has changed during the update (for instance, it is now in "multi-line comment" state, keep
     /// updating the next rows
     fn update_row(&mut self, y: usize, ignore_following_rows: bool) {
-        let mut hl_state = if y > 0 { self.rows[y - 1].hl_state } else { HLState::Normal };
+        let mut hl_state = if y > 0 { self.rows[y - 1].hl_state } else { HlState::Normal };
         for row in self.rows.iter_mut().skip(y) {
             let previous_hl_state = row.hl_state;
             hl_state = row.update(&self.syntax, hl_state, self.config.tab_stop);
@@ -315,7 +315,7 @@ impl Editor {
 
     /// Update all the rows.
     fn update_all_rows(&mut self) {
-        let mut hl_state = HLState::Normal;
+        let mut hl_state = HlState::Normal;
         for row in &mut self.rows {
             hl_state = row.update(&self.syntax, hl_state, self.config.tab_stop);
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@
 #[derive(Debug)]
 pub enum Error {
     /// Wrapper around `std::io::Error`
-    IO(std::io::Error),
+    Io(std::io::Error),
     /// Error returned when the window size obtained through a system call is invalid.
     InvalidWindowSize,
     /// Error setting or retrieving the cursor position.
@@ -19,5 +19,5 @@ pub enum Error {
 
 impl From<std::io::Error> for Error {
     /// Convert an IO Error into a Kibi Error.
-    fn from(err: std::io::Error) -> Self { Self::IO(err) }
+    fn from(err: std::io::Error) -> Self { Self::Io(err) }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -10,19 +10,19 @@ use crate::{sys, Error};
 /// to the discriminant, modulo 100. The colors are described here:
 /// <https://en.wikipedia.org/wiki/ANSI_escape_code#Colors>
 #[derive(PartialEq, Copy, Clone)]
-pub enum HLType {
+pub enum HlType {
     Normal = 39,     // Default foreground color
     Number = 31,     // Red
     Match = 46,      // Cyan
     String = 32,     // Green
-    MLString = 132,  // Green
+    MlString = 132,  // Green
     Comment = 34,    // Blue
-    MLComment = 134, // Blue
+    MlComment = 134, // Blue
     Keyword1 = 33,   // Yellow
     Keyword2 = 35,   // Magenta
 }
 
-impl Display for HLType {
+impl Display for HlType {
     /// Write the ANSI color escape sequence for the `HLType` using the given formatter.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result { write!(f, "\x1b[{}m", (*self as u32) % 100) }
 }
@@ -44,7 +44,7 @@ pub struct Conf {
     pub ml_string_delim: Option<String>,
     /// Keywords to highlight and there corresponding HLType (typically
     /// HLType::Keyword1 or HLType::Keyword2)
-    pub keywords: Vec<(HLType, Vec<String>)>,
+    pub keywords: Vec<(HlType, Vec<String>)>,
 }
 
 impl Conf {
@@ -82,8 +82,8 @@ impl Conf {
                         d => return Err(format!("Expected 2 delimiters, got {}", d.len())),
                     },
                 "multiline_string_delim" => sc.ml_string_delim = Some(pv(val)?),
-                "keywords_1" => sc.keywords.push((HLType::Keyword1, pvs(val)?)),
-                "keywords_2" => sc.keywords.push((HLType::Keyword2, pvs(val)?)),
+                "keywords_1" => sc.keywords.push((HlType::Keyword1, pvs(val)?)),
+                "keywords_2" => sc.keywords.push((HlType::Keyword2, pvs(val)?)),
                 _ => return Err(format!("Invalid key: {}", key)),
             }
             Ok(())


### PR DESCRIPTION
We use `UpperCamelCase` everywhere, following the  naming conventions from [RFC 430](https://github.com/rust-lang/rfcs/blob/master/text/0430-finalizing-naming-conventions.md).