### PR TITLE
Fix SELinux-related crash on Android devices

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 // On UNIX systems, termios represents the terminal mode.
 pub use libc::termios as TermMode;
 use libc::{c_int, c_void, sigaction, sighandler_t, siginfo_t, winsize};
-use libc::{SA_SIGINFO, STDIN_FILENO, STDOUT_FILENO, TCSAFLUSH, TIOCGWINSZ, VMIN, VTIME};
+use libc::{SA_SIGINFO, STDIN_FILENO, STDOUT_FILENO, TCSADRAIN, TIOCGWINSZ, VMIN, VTIME};
 
 use crate::Error;
 
@@ -91,7 +91,7 @@ pub fn has_window_size_changed() -> bool { WIN_CHANGED.swap(false, Ordering::Rel
 
 /// Set the terminal mode.
 pub fn set_term_mode(term: &TermMode) -> Result<(), Error> {
-    cerr(unsafe { libc::tcsetattr(STDIN_FILENO, TCSAFLUSH, term) })
+    cerr(unsafe { libc::tcsetattr(STDIN_FILENO, TCSADRAIN, term) })
 }
 
 /// Setup the termios to enable raw mode, and return the original termios.


### PR DESCRIPTION
This is issue is similar to termux/termux-packages#1359. `TCSAFLUSH` is no longer allowed in Android because of a security policy. The issue has been fixed by aosp/1491378 and will be available in the next Android release.

In the meantime, we will use `TCSADRAIN` instead of `TCSAFLUSH` when setting termios.

Fixes #87