### PR TITLE
Added support for WebAssembly as a compile target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,18 +16,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "fastrand"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
 
 [[package]]
 name = "instant"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
@@ -52,15 +52,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
+checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -92,18 +92,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -156,15 +156,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "syn"
-version = "1.0.77"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5239bc68e0fef57495900cfea4e8dc75596d9a319d7e16b1e0a440d24e6fe0a0"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -226,7 +226,7 @@ impl Editor {
                 self.update_window_size()?;
                 self.refresh_screen()?;
             }
-            let mut bytes = io::stdin().bytes();
+            let mut bytes = sys::stdin().bytes();
             // Match on the next byte received or, if the first byte is <ESC> ('\x1b'), on the next
             // few bytes.
             match bytes.next().transpose()? {
@@ -591,6 +591,7 @@ impl Editor {
             Key::Home => self.cursor.x = 0,
             Key::End => self.cursor.x = self.current_row().map_or(0, |row| row.chars.len()),
             Key::Char(b'\r') => self.insert_new_line(), // Enter
+            Key::Char(b'\n') => self.insert_new_line(), // Enter
             Key::Char(BACKSPACE) | Key::Char(DELETE_BIS) => self.delete_char(), // Backspace or Ctrl + H
             Key::Char(REMOVE_LINE) => self.delete_current_row(),
             Key::Delete => {
@@ -655,9 +656,9 @@ impl Editor {
     ///
     /// Will Return `Err` if any error occur.
     pub fn run(&mut self, file_name: Option<String>) -> Result<(), Error> {
-        if let Some(path) = file_name.as_ref().map(Path::new) {
-            self.select_syntax_highlight(path)?;
-            self.load(path)?;
+        if let Some(path) = file_name.as_ref().map(sys::path) {
+            self.select_syntax_highlight(path.as_path())?;
+            self.load(path.as_path())?;
         } else {
             self.rows.push(Row::new(Vec::new()));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,3 +17,6 @@ mod terminal;
 
 #[cfg(unix)] mod unix;
 #[cfg(unix)] use unix as sys;
+
+#[cfg(target_os="wasi")] mod wasi;
+#[cfg(target_os="wasi")] use wasi as sys;

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,6 +1,6 @@
 use std::io::{self, BufRead, Read, Write};
 
-use crate::{ansi_escape::DEVICE_STATUS_REPORT, ansi_escape::REPOSITION_CURSOR_END, Error};
+use crate::{sys, ansi_escape::DEVICE_STATUS_REPORT, ansi_escape::REPOSITION_CURSOR_END, Error};
 
 /// Obtain the window size using the cursor position.
 ///
@@ -13,7 +13,7 @@ pub fn get_window_size_using_cursor() -> Result<(usize, usize), Error> {
     print!("{}{}", REPOSITION_CURSOR_END, DEVICE_STATUS_REPORT);
     io::stdout().flush()?;
     let mut prefix_buffer = [0_u8; 2];
-    io::stdin().read_exact(&mut prefix_buffer)?;
+    sys::stdin().read_exact(&mut prefix_buffer)?;
     if prefix_buffer != [b'\x1b', b'['] {
         return Err(Error::CursorPosition);
     }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -109,3 +109,11 @@ pub fn enable_raw_mode() -> Result<TermMode, Error> {
     set_term_mode(&term)?;
     Ok(orig_term)
 }
+
+pub fn stdin() -> Box<dyn std::io::Read> {
+    Box::new(std::io::stdin())
+}
+
+pub fn path(filename: &String) -> std::path::PathBuf {
+    std::path::PathBuf::from(filename)
+}

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -1,0 +1,86 @@
+//! # sys (WASI)
+//!
+//! WASI-specific structs and functions. Will be imported as `sys` on WASI systems.
+
+use std::env::var;
+
+use crate::Error;
+
+#[allow(unused)]
+pub struct TermMode
+{
+}
+
+/// Return directories following the XDG Base Directory Specification
+///
+/// See `conf_dirs()` and `data_dirs()` for usage example.
+///
+/// The XDG Base Directory Specification is defined here:
+/// <https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html>
+fn xdg_dirs(xdg_type: &str, def_home_suffix: &str, def_dirs: &str) -> Vec<String> {
+    let (home_key, dirs_key) = (format!("XDG_{}_HOME", xdg_type), format!("XDG_{}_DIRS", xdg_type));
+
+    let mut dirs = Vec::new();
+
+    // If environment variable `home_key` (e.g. `$XDG_CONFIG_HOME`) is set, add its value to `dirs`.
+    // Otherwise, if environment variable `$HOME` is set, add `$HOME{def_home_suffix}`
+    // (e.g. `$HOME/.config`) to `dirs`.
+    dirs.extend(var(home_key).or_else(|_| var("HOME").map(|d| d + def_home_suffix)).into_iter());
+
+    // If environment variable `dirs_key` (e.g. `XDG_CONFIG_DIRS`) is set, split by `:` and add the
+    // parts to `dirs`.
+    // Otherwise, add the split `def_dirs` (e.g. `/etc/xdg:/etc`) and add the parts to `dirs`.
+    dirs.extend(var(dirs_key).unwrap_or_else(|_| def_dirs.into()).split(':').map(String::from));
+
+    dirs.into_iter().map(|p| p + "/kibi").collect()
+}
+
+/// Return configuration directories for UNIX systems
+pub fn conf_dirs() -> Vec<String> { xdg_dirs("CONFIG", "/.config", "/etc/xdg:/etc") }
+
+/// Return syntax directories for UNIX systems
+pub fn data_dirs() -> Vec<String> {
+    xdg_dirs("DATA", "/.local/share", "/usr/local/share/:/usr/share/")
+}
+
+/// Return the current window size as (rows, columns).
+/// By returning an error we cause kibi to fall back to another method of getting the window size
+pub fn get_window_size() -> Result<(usize, usize), Error> {
+    Err(Error::InvalidWindowSize)
+}
+
+/// Register a signal handler that sets a global variable when the window size changes.
+/// After calling this function, use has_window_size_changed to query the global variable.
+pub fn register_winsize_change_signal_handler() -> Result<(), Error> {
+    Ok(())
+}
+
+/// Check if the windows size has changed since the last call to this function.
+/// The register_winsize_change_signal_handler needs to be called before this function.
+pub fn has_window_size_changed() -> bool {
+    false
+}
+
+/// Set the terminal mode (this does nothing)
+pub fn set_term_mode(_term: &TermMode) -> Result<(), Error> {
+    Ok(())
+}
+
+/// Opening the file /dev/tty is effectively the same as raw_mode
+pub fn enable_raw_mode() -> Result<TermMode, Error> {
+    Ok(TermMode {})
+}
+
+pub fn stdin() -> Box<dyn std::io::Read> {
+    Box::new(std::fs::File::open("/dev/tty").unwrap())
+}
+
+pub fn path(filename: &String) -> std::path::PathBuf {
+    if filename.starts_with("/") {
+        std::path::PathBuf::from(filename)
+    } else {
+        let cur_dir = var("PWD").unwrap_or("/".to_string());
+        let path = std::path::PathBuf::from(cur_dir);
+        path.join(filename)
+    }
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -58,3 +58,11 @@ pub fn enable_raw_mode() -> Result<TermMode, Error> {
     set_term_mode(&(mode_in, mode_out))?;
     Ok((mode_in0, mode_out0))
 }
+
+pub fn stdin() -> Box<dyn std::io::Read> {
+    Box::new(std::io::stdin())
+}
+
+pub fn path(filename: &String) -> std::path::PathBuf {
+    std::path::PathBuf::from(filename)
+}


### PR DESCRIPTION
This pull request adds support for wasm32-wasi as a compile target.

Check out the running version of kibi on tokera.sh...
https://tokera.sh/

Type 'kibi' to launch the editor in your browser.