### PR TITLE
returns error for 'special' file types (e.g. unix devices)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install gcc-multilib
         if: matrix.target == 'i686-unknown-linux-gnu'
-        run: sudo apt-get install gcc-multilib
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-multilib
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::wildcard_imports)]
 
-use std::io::{self, BufRead, BufReader, ErrorKind::NotFound, Read, Seek, Write};
+use std::io::{
+    self, BufRead, BufReader, ErrorKind::InvalidInput, ErrorKind::NotFound, Read, Seek, Write,
+};
 use std::iter::{self, repeat, successors};
 use std::{fmt::Display, fs::File, path::Path, process::Command, thread, time::Instant};
 
@@ -422,6 +424,10 @@ impl Editor {
     /// Try to load a file. If found, load the rows and update the render and syntax highlighting.
     /// If not found, do not return an error.
     fn load(&mut self, path: &Path) -> Result<(), Error> {
+        if !std::fs::metadata(path)?.file_type().is_file() {
+            return Err(io::Error::new(InvalidInput, "Invalid input file type").into());
+        }
+
         match File::open(path) {
             Ok(file) => {
                 for line in BufReader::new(file).split(b'\n') {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -424,7 +424,8 @@ impl Editor {
     /// Try to load a file. If found, load the rows and update the render and syntax highlighting.
     /// If not found, do not return an error.
     fn load(&mut self, path: &Path) -> Result<(), Error> {
-        if !std::fs::metadata(path)?.file_type().is_file() {
+        let ft = std::fs::metadata(path)?.file_type();
+        if !(ft.is_file() || ft.is_symlink()) {
             return Err(io::Error::new(InvalidInput, "Invalid input file type").into());
         }
 


### PR DESCRIPTION
allows editing only actual files, e.g. no block/char device, FIFO, directory...
~~added also new option to strip out debug info in release build~~
fix #166 
still below 1024 lines of code :)