### PR TITLE
Change quit keybind

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -9,7 +9,7 @@ use crate::row::{HlState, Row};
 use crate::{ansi_escape::*, syntax::Conf as SyntaxConf, sys, terminal, Config, Error};
 
 const fn ctrl_key(key: u8) -> u8 { key & 0x1f }
-const EXIT: u8 = ctrl_key(b'Q');
+const EXIT: u8 = ctrl_key(b'W');
 const DELETE_BIS: u8 = ctrl_key(b'H');
 const REFRESH_SCREEN: u8 = ctrl_key(b'L');
 const SAVE: u8 = ctrl_key(b'S');
@@ -21,7 +21,7 @@ const REMOVE_LINE: u8 = ctrl_key(b'R');
 const BACKSPACE: u8 = 127;
 
 const HELP_MESSAGE: &str =
-    "Ctrl-S = save | Ctrl-Q = quit | Ctrl-F = find | Ctrl-G = go to | Ctrl-D = duplicate | Ctrl-E = execute";
+    "Ctrl-S = save | Ctrl-W = quit | Ctrl-F = find | Ctrl-G = go to | Ctrl-D = duplicate | Ctrl-E = execute";
 
 /// `set_status!` sets a formatted status message for the editor.
 /// Example usage: `set_status!(editor, "{} written to {}", file_size, file_name)`


### PR DESCRIPTION
Done to prevent clashing with the common keybind in Linux DE's to close the current _window_ with Ctrl-Q.