### PR TITLE
Added implementation for copy, cut and paste

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,15 @@ jobs:
           # MSRV (Linux)
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            toolchain: 1.53.0
+            toolchain: 1.59.0
           # MSRV (MacOS)
           - os: macos-latest
             target: x86_64-apple-darwin
-            toolchain: 1.53.0
+            toolchain: 1.59.0
           # MSRV (Windows)
           - os: windows-latest
             target: x86_64-pc-windows-gnu
-            toolchain: 1.53.0
+            toolchain: 1.59.0
 
           # Nightly (Linux)
           - os: ubuntu-latest
@@ -122,7 +122,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.53.0  # MSRV
+          - 1.59.0  # MSRV
           - nightly
     env:
       CARGO_TERM_COLOR: always

--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ kibi --version    # Print version information and exit
 | Ctrl-D            | Duplicate the current row                                     |
 | Ctrl-E            | Execute an external command and paste its output              |
 | Ctrl-R            | Remove an entire line                                         |
+| Ctrl-C            | Copies the entire line                                        |
+| Ctrl-X            | Cuts the entire line                                          |
+| Ctrl-V            | Will paste the copied line                                    |
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://img.shields.io/github/workflow/status/ilai-deutel/kibi/CI/master?logo=github-actions)](https://github.com/ilai-deutel/kibi/actions/workflows/ci.yml?query=branch%3Amaster)
 [![Crate](https://img.shields.io/crates/v/kibi.svg)](https://crates.io/crates/kibi)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.53+-blue.svg?logo=rust)](https://www.rust-lang.org/)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.59+-blue.svg?logo=rust)](https://www.rust-lang.org/)
 [![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows%2010-blue)](#)
 [![Packaging status](https://repology.org/badge/tiny-repos/kibi.svg)](https://repology.org/project/kibi/versions)
 [![Dependency Status](https://deps.rs/repo/github/ilai-deutel/kibi/status.svg)](https://deps.rs/repo/github/ilai-deutel/kibi)

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 fn main() {
-    let version = match Command::new("git").args(&["describe", "--tags", "--match=v*"]).output() {
+    let version = match Command::new("git").args(["describe", "--tags", "--match=v*"]).output() {
         Ok(output) if output.status.success() =>
             String::from_utf8_lossy(&output.stdout[1..]).replacen('-', ".r", 1).replace('-', "."),
         _ => env!("CARGO_PKG_VERSION").into(),

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -284,7 +284,7 @@ impl Editor {
     fn update_window_size(&mut self) -> Result<(), Error> {
         let wsize = sys::get_window_size().or_else(|_| terminal::get_window_size_using_cursor())?;
         // Make room for the status bar and status message
-        (self.screen_rows, self.window_width) = (wsize.0.saturating_sub(2), wsize.1); 
+        (self.screen_rows, self.window_width) = (wsize.0.saturating_sub(2), wsize.1);
         self.update_screen_cols();
         Ok(())
     }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -123,8 +123,8 @@ pub struct Editor {
     n_bytes: u64,
     /// The original terminal mode. It will be restored when the `Editor` instance is dropped.
     orig_term_mode: Option<sys::TermMode>,
-	/// The copied buffer of a row
-	copied_row: Vec<u8>,
+    /// The copied buffer of a row
+    copied_row: Vec<u8>,
 }
 
 /// Describes a status message, shown at the bottom at the screen.
@@ -414,31 +414,28 @@ impl Editor {
 
     fn duplicate_current_row(&mut self) {
         self.copy_current_row();
-		self.paste_current_row();
-		self.copied_row.clear();
+        self.paste_current_row();
     }
 
-	fn copy_current_row(&mut self) {
-        if let Some(row) = self.current_row() {
-            self.copied_row = row.chars.clone();
-        }
+    fn copy_current_row(&mut self) { 
+        if let Some(row) = self.current_row() { self.copied_row = row.chars.clone(); }
     }
 
-	fn cut_current_row(&mut self) {
+    fn cut_current_row(&mut self) {
         self.copy_current_row();
-		self.delete_current_row();
+        self.delete_current_row();
     }
 
-	fn paste_current_row(&mut self) {
-		if self.copied_row.is_empty() { return; }
-		let new_row = Row::new(self.copied_row.clone());
-		self.n_bytes += new_row.chars.len() as u64;
-		self.rows.insert(self.cursor.y + 1, new_row);
-		self.update_row(self.cursor.y + 1, false);
-		self.cursor.y += 1;
-		self.dirty = true;
-		// The line number has changed
-		self.update_screen_cols();
+    fn paste_current_row(&mut self) {
+        if self.copied_row.is_empty() { return; }
+        let new_row = Row::new(self.copied_row.clone());
+        self.n_bytes += new_row.chars.len() as u64;
+        self.rows.insert(self.cursor.y + 1, new_row);
+        self.update_row(self.cursor.y + 1, false);
+        self.cursor.y += 1;
+        self.dirty = true;
+        // The line number has changed
+        self.update_screen_cols();
     }
 
     /// Try to load a file. If found, load the rows and update the render and syntax highlighting.

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -24,7 +24,7 @@ const REMOVE_LINE: u8 = ctrl_key(b'R');
 const BACKSPACE: u8 = 127;
 
 const HELP_MESSAGE: &str =
-    "Ctrl-S = save | Ctrl-Q = quit | Ctrl-F = find | Ctrl-G = go to | Ctrl-D = duplicate | Ctrl-E = execute | Ctrl-C = copy | Ctrl-X = cut | Ctrl-V = paste";
+    "^S save | ^Q quit | ^F find | ^G go to | ^D duplicate | ^E execute | ^C copy | ^X cut | ^V paste";
 
 /// `set_status!` sets a formatted status message for the editor.
 /// Example usage: `set_status!(editor, "{} written to {}", file_size, file_name)`

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -664,7 +664,7 @@ impl Editor {
             current = (current + if forward { 1 } else { num_rows - 1 }) % num_rows;
             let row = &mut self.rows[current];
             if let Some(cx) = slice_find(&row.chars, query.as_bytes()) {
-                (self.cursor.x, self.cursor.y) = (cx, current as usize);
+                (self.cursor.x, self.cursor.y) = (cx, current);
                 // Try to reset the column offset; if the match is after the offset, this
                 // will be updated in self.cursor.scroll() so that the result is visible
                 self.cursor.coff = 0;

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -24,7 +24,7 @@ const REMOVE_LINE: u8 = ctrl_key(b'R');
 const BACKSPACE: u8 = 127;
 
 const HELP_MESSAGE: &str =
-    "Ctrl-S = save | Ctrl-Q = quit | Ctrl-F = find | Ctrl-G = go to | Ctrl-D = duplicate | Ctrl-E = execute";
+    "Ctrl-S = save | Ctrl-Q = quit | Ctrl-F = find | Ctrl-G = go to | Ctrl-D = duplicate | Ctrl-E = execute | Ctrl-C = copy | Ctrl-X = cut | Ctrl-V = paste";
 
 /// `set_status!` sets a formatted status message for the editor.
 /// Example usage: `set_status!(editor, "{} written to {}", file_size, file_name)`
@@ -416,10 +416,8 @@ impl Editor {
     }
 
     fn copy_current_row(&mut self, is_preserving: bool) {
-        if let Some(row) = self.current_row() {
-            self.copied_row = row.chars.clone();
-            if !is_preserving { self.delete_current_row(); }
-        }
+        if let Some(row) = self.current_row() { self.copied_row = row.chars.clone(); }
+        if !is_preserving { self.delete_current_row(); }
     }
 
     fn paste_current_row(&mut self) {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -160,6 +160,7 @@ fn slice_find<T: PartialEq>(s: &[T], needle: &[T]) -> Option<usize> {
     (0..(s.len() + 1).saturating_sub(needle.len())).find(|&i| s[i..].starts_with(needle))
 }
 
+#[rustfmt::skip]
 impl Editor {
     /// Initialize the text editor.
     ///

--- a/src/row.rs
+++ b/src/row.rs
@@ -205,7 +205,7 @@ impl Row {
                     buffer.push_str(&hl_type.to_string());
                     current_hl_type = *hl_type;
                 }
-                buffer.push(c as char);
+                buffer.push(c);
             }
             rx += c.width().unwrap_or(1);
         }


### PR DESCRIPTION
Using the usual ctrl+c, ctrl+x, ctrl+v, you can copy, cut and paste the new lines. 
- I implemented a character buffer that copies the line into every time you press copy or cut, and can paste it anywhere in the file
- I reused the implementation of duplicate, and now duplicate is just a combination of the copy and paste methods, so as to reduce the number of duplicate lines.
- I updated the README.md to reflect these changes. 
- I updated the minimum rust version from 1.53 to 1.59, because I needed the destructuring assignment (https://blog.rust-lang.org/2022/02/24/Rust-1.59.0.html), so as to reduce the number of lines. 

Some other clippy issues were found, regarding some borrowing and some casting, which now should be solved.

This closes # 22 (delete the space when sending to upstream)

Signed-off-by: Robert Grancsa [robert.grancsa2002@gmail.com](mailto:robert.grancsa2002@gmail.com)