### PR TITLE
Add syntax highlighting support for 11 languages

### DIFF
--- a/syntax.d/coffeescript.ini
+++ b/syntax.d/coffeescript.ini
@@ -1,0 +1,9 @@
+name=CoffeeScript
+extensions=coffee, litcoffee
+highlight_numbers=true
+singleline_comment_start=#
+multiline_comment_delims=###, ###
+singleline_string_quotes="
+multiline_string_delim="
+keywords_1=this, new, if, else, return, try, catch, throw, function, class, extends, super, switch, case, default, break, continue, for, in, while, do, unless, until
+keywords_2=true, false, null, undefined

--- a/syntax.d/d.ini
+++ b/syntax.d/d.ini
@@ -1,0 +1,9 @@
+name=D
+extensions=d
+highlight_numbers=true
+singleline_string_quotes="
+singleline_comment_start=//
+multiline_comment_delims=/*, */
+multiline_string_delim="
+keywords_1=abstract, alias, align, asm, assert, auto, body, bool, break, byte, case, cast, catch, cdouble, cent, cfloat, char, class, const, continue, creal, dchar, debug, default, delegate, delete, deprecated, do, double, else, enum, export, extern, false, final, float, for, foreach, foreach_reverse, function, goto, idouble, if, ifloat, immutable, import, in, inout, int, interface, invariant, ireal, is, lazy, long, macro, mixin, module, new, nothrow, null, out, override, package, pragma, private, protected, public, pure, real, ref, return, scope, shared, short, static, struct, super, switch, synchronized, template, this, throw, true, try, typeid, typeof, ubyte, ucent, uint, ulong, union, unittest, ushort, version, void, volatile, wchar, while, with
+keywords_2=cstring, delegate, function, interface, package, typeid, typeof

--- a/syntax.d/groovy.ini
+++ b/syntax.d/groovy.ini
@@ -1,0 +1,9 @@
+name=Groovy
+extensions=groovy
+highlight_numbers=true
+singleline_string_quotes="
+singleline_comment_start=//
+multiline_comment_delims=/*, */
+multiline_string_delim="
+keywords_1=as, assert, break, case, catch, class, const, continue, def, default, do, else, enum, extends, false, finally, for, if, implements, import, in, instanceof, interface, new, null, package, return, super, switch, this, throw, throws, true, try, while
+keywords_2=byte, char, double, float, int, long, short, boolean, void

--- a/syntax.d/groovy.ini
+++ b/syntax.d/groovy.ini
@@ -4,6 +4,6 @@ highlight_numbers=true
 singleline_string_quotes="
 singleline_comment_start=//
 multiline_comment_delims=/*, */
-multiline_string_delim=""", '''
+multiline_string_delim='''
 keywords_1=as, assert, break, case, catch, class, const, continue, def, default, do, else, enum, extends, false, finally, for, if, implements, import, in, instanceof, interface, new, null, package, return, super, switch, this, throw, throws, true, try, while
 keywords_2=byte, char, double, float, int, long, short, boolean, void

--- a/syntax.d/groovy.ini
+++ b/syntax.d/groovy.ini
@@ -4,6 +4,6 @@ highlight_numbers=true
 singleline_string_quotes="
 singleline_comment_start=//
 multiline_comment_delims=/*, */
-multiline_string_delim="
+multiline_string_delim=""", '''
 keywords_1=as, assert, break, case, catch, class, const, continue, def, default, do, else, enum, extends, false, finally, for, if, implements, import, in, instanceof, interface, new, null, package, return, super, switch, this, throw, throws, true, try, while
 keywords_2=byte, char, double, float, int, long, short, boolean, void

--- a/syntax.d/julia.ini
+++ b/syntax.d/julia.ini
@@ -1,0 +1,9 @@
+name=Julia
+extensions=jl,julia
+highlight_numbers=true
+singleline_string_quotes="
+singleline_comment_start=#
+multiline_comment_delims=#=, =#
+multiline_string_delim="
+keywords_1=begin, break, catch, const, continue, do, else, elseif, end, export, false, finally, for, function, global, if, import, in, let, local, macro, module, quote, return, true, try, using, while
+keywords_2=abstract, baremodule, bitstype, mutable struct, primitive type, struct

--- a/syntax.d/matlab.ini
+++ b/syntax.d/matlab.ini
@@ -1,0 +1,6 @@
+name=MATLAB
+extensions=m
+highlight_numbers=true
+singleline_comment_start=%
+multiline_comment_delims=%{, %}
+multiline_string_delim="

--- a/syntax.d/nix.ini
+++ b/syntax.d/nix.ini
@@ -1,0 +1,8 @@
+name=Nix
+extensions=nix
+highlight_numbers=true
+singleline_string_quotes="
+singleline_comment_start=#
+multiline_comment_delims=/*, */
+multiline_string_delim="
+keywords_1=if, then, else, with, assert, let, in, inherit, rec, or, and, null, true, false, import, as, from

--- a/syntax.d/nix.ini
+++ b/syntax.d/nix.ini
@@ -4,5 +4,5 @@ highlight_numbers=true
 singleline_string_quotes="
 singleline_comment_start=#
 multiline_comment_delims=/*, */
-multiline_string_delim="
+multiline_string_delim=''
 keywords_1=if, then, else, with, assert, let, in, inherit, rec, or, and, null, true, false, import, as, from

--- a/syntax.d/nushell.ini
+++ b/syntax.d/nushell.ini
@@ -1,0 +1,8 @@
+name=NuShell
+extensions=nu
+highlight_numbers=true
+singleline_string_quotes="
+singleline_comment_start=#
+multiline_string_delim="
+keywords_1=alias, and, assert, cd, config, cp, declare, def, do, each, echo, else, eval, exit, export, for, get, if, import, let, match, not, or, path, rm, set, then, to, where
+keywords_2=true, false, yes, no, null

--- a/syntax.d/ocaml.ini
+++ b/syntax.d/ocaml.ini
@@ -1,0 +1,9 @@
+name=OCaml
+extensions=ml,mli
+highlight_numbers=true
+singleline_string_quotes="
+singleline_comment_start=//
+multiline_comment_delims=(*, *)
+multiline_string_delim="
+keywords_1=and, as, assert, begin, class, constraint, do, done, downto, else, end, exception, external, false, for, fun, function, functor, if, in, include, inherit, initializer, land, lazy, let, lor, lsl, lsr, lxor, match, method, mod, module, mutable, new, nonrec, object, of, open, or, private, rec, sig, struct, then, to, true, try, type, val, virtual, when, while, with
+keywords_2=int, float, bool, char, string, list, array, unit, option

--- a/syntax.d/processing.ini
+++ b/syntax.d/processing.ini
@@ -1,0 +1,9 @@
+name=Processing
+extensions=pde
+highlight_numbers=true
+singleline_string_quotes="
+singleline_comment_start=//
+multiline_comment_delims=/*, */
+multiline_string_delim="
+keywords_1=boolean, break, byte, case, char, class, continue, default, do, double, else, false, float, for, if, int, long, new, null, return, short, static, super, switch, this, true, void, while
+keywords_2=setup, draw, size, background, fill, rect, ellipse, line, stroke, strokeWeight, mouseX, mouseY, width, height

--- a/syntax.d/raku.ini
+++ b/syntax.d/raku.ini
@@ -1,0 +1,9 @@
+name=Raku
+extensions=raku, p6, pl6, pm6, nqp
+highlight_numbers=true
+singleline_string_quotes="
+singleline_comment_start=#
+multiline_comment_delims=#`{, }#
+multiline_string_delim="
+keywords_1=class, role, unit, module, use, is, does, has, method, sub, multi, submethod, proto, given, when, default, else, if, unless, loop, while, repeat, until, for, my, our, state, constant, return, given, when, temp, let, where, with, say, warn, die, try, CATCH, LEAVE, FIRST, NEXT, LAST, BEGIN, END
+keywords_2=Int, Num, Str, Rat, Bool, Any, Junction, Capture, Mu, Cool, Scalar, Array, Hash, List, Iterable, Callable, Regex, Match, Signature, Routine, Block, Code, Whatever, Parcel, Map, Set, Bag, Mix

--- a/syntax.d/zig.ini
+++ b/syntax.d/zig.ini
@@ -1,0 +1,9 @@
+name=Zig
+extensions=zig, zir
+highlight_numbers=true
+singleline_string_quotes="
+singleline_comment_start=//
+multiline_comment_delims=/*, */
+multiline_string_delim="
+keywords_1=align, and, anyframe, anytype, asm, async, await, break, catch, comptime, const, continue, defer, else, enum, errdefer, error, export, extern, false, fn, for, if, inline, nakedcc, nakec, noalias, noreturn, null, or, orelse, packed, return, struct, switch, suspend, test, true, try, undefined, union, unreachable, usingnamespace, var, volatile, while
+keywords_2=i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, f16, f32, f64, bool, char, void


### PR DESCRIPTION
Added syntax highlighting support for the following languages:

1. CoffeeScript
2. D
3. Groovy
4. Julia
5. Matlab
6. Nix
7. NuShell
8. Ocaml
9. Processing
10. Raku
11. Zig