### PR TITLE
add configuration item : terminal_encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 .idea
 release_files
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +168,7 @@ checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 name = "kibi"
 version = "0.2.2"
 dependencies = [
+ "encoding_rs",
  "libc",
  "serial_test",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ include = ["src/**/*", "Cargo.toml", "LICENSE*", "COPYRIGHT"]
 
 [dependencies]
 unicode-width = "0.1.11"
+encoding_rs="0.8.33"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.150"

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,8 @@ use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::{fmt::Display, fs::File, str::FromStr, time::Duration};
 
+use encoding_rs::Encoding;
+
 use crate::{sys::conf_dirs as cdirs, Error, Error::Config as ConfErr};
 
 /// The global Kibi configuration.
@@ -20,12 +22,14 @@ pub struct Config {
     pub message_dur: Duration,
     /// Whether to display line numbers.
     pub show_line_num: bool,
+    /// encoding of the cmd of windows or shell of *nix
+    pub terminal_encoding: Option<&'static Encoding>
 }
 
 impl Default for Config {
     /// Default configuration.
     fn default() -> Self {
-        Self { tab_stop: 4, quit_times: 2, message_dur: Duration::new(3, 0), show_line_num: true }
+        Self { tab_stop: 4, quit_times: 2, message_dur: Duration::new(3, 0), show_line_num: true, terminal_encoding: None }
     }
 }
 
@@ -58,6 +62,10 @@ impl Config {
                     "message_duration" =>
                         conf.message_dur = Duration::from_secs_f32(parse_value(value)?),
                     "show_line_numbers" => conf.show_line_num = parse_value(value)?,
+                    "terminal_encoding" => {
+                        let encoding_label:String = parse_value(value)?;
+                        conf.terminal_encoding = encoding_rs::Encoding::for_label(encoding_label.as_bytes());
+                    },
                     _ => return Err(format!("Invalid key: {key}")),
                 };
                 Ok(())


### PR DESCRIPTION
to support different cmd or shell  encoding enviroment when execute external command

remove windows line break character \r when paste command's output to editor