### PR TITLE
Find multiple matches on the same line.

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -671,6 +671,7 @@ impl Editor {
         let num_rows = self.rows.len();
         let mut cur = lst.unwrap_or_else(|| (usize::MAX, num_rows.saturating_sub(1)));
         while {
+            // TODO: add find backwards on the same line
             let row = &mut self.rows[cur.1];
             let slice = if cur.0 == usize::MAX { &row.chars[..] } else { &row.chars[cur.0 + 1..] };
             if let Some(cx) = slice_find(slice, q.as_bytes()) {
@@ -679,11 +680,10 @@ impl Editor {
                 let rx = row.cx2rx[cur.0];
                 row.match_segment = Some(rx..rx + q.len());
                 return Some(cur);
-            } else {
-                cur = (usize::MAX, (cur.1 + if fw { 1 } else { num_rows - 1 }) % num_rows);
             }
-            // if it wrapped back to the starting point
-            cur == lst.unwrap_or_else(|| (usize::MAX, num_rows.saturating_sub(1)))
+            cur = (usize::MAX, (cur.1 + if fw { 1 } else { num_rows - 1 }) % num_rows);
+            // if it wrapped back to the starting line
+            cur.1 != lst.map_or(num_rows.saturating_sub(1), |lst| lst.1)
         } {}
         None
     }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -663,26 +663,27 @@ impl Editor {
     }
 
     /// Try to find a query, this is called after pressing Ctrl-F and for each key that is pressed.
-    /// `last_match` is the last row that was matched, `forward` indicates whether to search forward
-    /// or backward. Returns the row of a new match, or `None` if the search was unsuccessful.
+    /// `q` represents the query, `lst` is the last position that was matched, `fw` indicates
+    /// whether to search forward or backward. Returns the position of a new match, or `None`
+    /// if the search was unsuccessful.
     #[allow(clippy::trivially_copy_pass_by_ref)] // This Clippy recommendation is only relevant on 32 bit platforms.
-    fn find(&mut self, query: &str, last_match: &Option<(usize, usize)>, fwd: bool) -> Option<(usize, usize)> {
+    fn find(&mut self, q: &str, lst: &Option<(usize, usize)>, fw: bool) -> Option<(usize, usize)> {
         let num_rows = self.rows.len();
-        let mut cur = last_match.unwrap_or_else(|| (usize::MAX, num_rows.saturating_sub(1)));
+        let mut cur = lst.unwrap_or_else(|| (usize::MAX, num_rows.saturating_sub(1)));
         while {
             let row = &mut self.rows[cur.1];
             let slice = if cur.0 == usize::MAX { &row.chars[..] } else { &row.chars[cur.0 + 1..] };
-            if let Some(cx) = slice_find(slice, query.as_bytes()) {
+            if let Some(cx) = slice_find(slice, q.as_bytes()) {
                 cur.0 = if cur.0 == usize::MAX { cx } else { cur.0 + cx + 1 };
                 (self.cursor.x, self.cursor.y, self.cursor.coff) = (cur.0, cur.1, 0);
                 let rx = row.cx2rx[cur.0];
-                row.match_segment = Some(rx..rx + query.len());
+                row.match_segment = Some(rx..rx + q.len());
                 return Some(cur);
             } else {
-                cur = (usize::MAX, (cur.1 + if fwd { 1 } else { num_rows - 1 }) % num_rows);
+                cur = (usize::MAX, (cur.1 + if fw { 1 } else { num_rows - 1 }) % num_rows);
             }
             // if it wrapped back to the starting point
-            cur == last_match.unwrap_or_else(|| (usize::MAX, num_rows.saturating_sub(1)))
+            cur == lst.unwrap_or_else(|| (usize::MAX, num_rows.saturating_sub(1)))
         } {}
         None
     }


### PR DESCRIPTION
I modified find so that it can show multiple matches on the same line.
- Changed the last_match variable so that it holds both coordinates of the last match
- If a key has been found on the current row, the next search is performed in a slice starting after the key.