### PR TITLE
Use alternate screen

### DIFF
--- a/src/ansi_escape.rs
+++ b/src/ansi_escape.rs
@@ -1,7 +1,10 @@
 //! # ANSI Escape sequences
 
-/// Clear from cursor to beginning of the screen
-pub const CLEAR_SCREEN: &str = "\x1b[2J";
+/// Switches to the main buffer.
+pub(crate) const USE_MAIN_SCREEN: &str = "\x1b[?1049l";
+
+/// Switches to a new alternate screen buffer.
+pub(crate) const USE_ALTERNATE_SCREEN: &str = "\x1b[?1049h";
 
 /// Reset the formatting
 pub(crate) const RESET_FMT: &str = "\x1b[m";
@@ -10,7 +13,7 @@ pub(crate) const RESET_FMT: &str = "\x1b[m";
 pub(crate) const REVERSE_VIDEO: &str = "\x1b[7m";
 
 /// Move the cursor to 1:1
-pub const MOVE_CURSOR_TO_START: &str = "\x1b[H";
+pub(crate) const MOVE_CURSOR_TO_START: &str = "\x1b[H";
 
 /// DECTCTEM: Make the cursor invisible
 pub(crate) const HIDE_CURSOR: &str = "\x1b[?25l";

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -170,8 +170,9 @@ impl Editor {
 
         // Enable raw mode and store the original (non-raw) terminal mode.
         editor.orig_term_mode = Some(sys::enable_raw_mode()?);
-        editor.update_window_size()?;
+        print!("{USE_ALTERNATE_SCREEN}");
 
+        editor.update_window_size()?;
         set_status!(editor, "{}", HELP_MESSAGE);
 
         Ok(editor)
@@ -723,7 +724,7 @@ impl Drop for Editor {
             sys::set_term_mode(&orig_term_mode).expect("Could not restore original terminal mode.");
         }
         if !thread::panicking() {
-            print!("{CLEAR_SCREEN}{MOVE_CURSOR_TO_START}");
+            print!("{USE_MAIN_SCREEN}");
             io::stdout().flush().expect("Could not flush stdout");
         }
     }


### PR DESCRIPTION
This avoids flicking when fast resizing the terminal windows. It also restore the content of terminal on exit.