### PR TITLE
Add vscode settings for using nightly rustfmt

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.rustfmt.extraArgs": ["+nightly"]
+}


### PR DESCRIPTION
This makes vscode automatically use the correct formatting when saving
