### PR TITLE
Added find & replace, and a shortcut to display the help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ kibi --version    # Print version information and exit
 
 | Keyboard shortcut | Description                                                   |
 | ----------------- | ------------------------------------------------------------- |
-| Ctrl-F            | Incremental search; use arrows to navigate                    |
+| Ctrl-F            | Incremental search; use arrows to navigate; Ctrl-R to replace |
 | Ctrl-S            | Save the buffer to the current file, or specify the file path |
 | Ctrl-G            | Go to `<line number>[:<column number>]` position              |
 | Ctrl-Q            | Quit                                                          |
@@ -203,6 +203,7 @@ kibi --version    # Print version information and exit
 | Ctrl-C            | Copies the entire line                                        |
 | Ctrl-X            | Cuts the entire line                                          |
 | Ctrl-V            | Will paste the copied line                                    |
+| Ctrl-P            | Sets the help message in the status                           |
 | Ctrl-LeftArrow    | Moves cursor to previous word                                 |
 | Ctrl-RightArrow   | Moves cursor to next word                                     |
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -18,13 +18,14 @@ const GOTO: u8 = ctrl_key(b'G');
 const CUT: u8 = ctrl_key(b'X');
 const COPY: u8 = ctrl_key(b'C');
 const PASTE: u8 = ctrl_key(b'V');
+const HELP: u8 = ctrl_key(b'P');
 const DUPLICATE: u8 = ctrl_key(b'D');
 const EXECUTE: u8 = ctrl_key(b'E');
 const REMOVE_LINE: u8 = ctrl_key(b'R');
 const BACKSPACE: u8 = 127;
 
 const HELP_MESSAGE: &str = "^S save | ^Q quit | ^F find | ^G go to | ^D duplicate | ^E execute | \
-                            ^C copy | ^X cut | ^V paste";
+                            ^C copy | ^X cut | ^V paste | ^P help";
 
 /// `set_status!` sets a formatted status message for the editor.
 /// Example usage: `set_status!(editor, "{} written to {}", file_size,
@@ -675,6 +676,7 @@ impl Editor {
             Key::Char(COPY) => self.copy_current_row(),
             Key::Char(PASTE) => self.paste_current_row(),
             Key::Char(EXECUTE) => prompt_mode = Some(PromptMode::Execute(String::new())),
+            Key::Char(HELP) => set_status!(self, "{}", HELP_MESSAGE),
             Key::Char(c) => self.insert_byte(*c),
         }
         self.quit_times = quit_times;


### PR DESCRIPTION
## Find & Replace
- when in find mode, use `^R` to enter replace mode
- in replace mode you can still navigate like in find mode with arrow keys/ctrl-f, esc, enter
- in replace mode you can do `^R` to replace the current match with the current prompt buffer

## Help Message Shortcut
- use ^P to set the current status to the help message again

## LOC
```
Total (unix)       1024  (≤ 1024)
Total (wasi)        995  (≤ 1024)
Total (windows)    1009  (≤ 1024)
```