### PR TITLE
Add support for end-of-options delimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)._
 
+## [Unreleased]
+
+### Added
+
+- Support for end-of-options delimiter `--` (following [POSIX.1-2024 12. Utility Conventions](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html)), allowing Kibi to be used as the editor for the *`sudoers`* file with [`visudo`](https://www.man7.org/linux/man-pages/man8/visudo.8.html) ([#480](https://github.com/ilai-deutel/kibi/pull/480))
+
 ## [0.3.0] - 2025-10-26
 
 ### Added
@@ -134,6 +140,7 @@ kibi v0.1.1 is a small patch release that includes a minor fix to the
 
 Initial release
 
+[unreleased]: https://github.com/olivierlacan/ilai-deutel/kibi/v0.3.0...HEAD
 [0.3.0]: https://github.com/ilai-deutel/kibi/releases/tag/v0.3.0
 [0.2.2]: https://github.com/ilai-deutel/kibi/releases/tag/v0.2.2
 [0.2.1]: https://github.com/ilai-deutel/kibi/releases/tag/v0.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
 dependencies = [
  "log",
- "regex",
 ]
 
 [[package]]
@@ -653,6 +652,7 @@ dependencies = [
  "env_logger",
  "libc",
  "log",
+ "rstest",
  "tempfile",
  "unicode-width",
  "winapi",
@@ -1010,6 +1010,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,6 +1089,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,10 @@ winapi = { version = "0.3.9", default-features = false, features = ["wincon"] }
 winapi-util = "0.1.11"
 
 [dev-dependencies]
-env_logger = "0.11.8"
-log = "0.4.28"
-tempfile = "3.23.0"
+env_logger = { version = "0.11.8", default-features = false, features = ["auto-color", "humantime"] }
+log = { version = "0.4.28", default-features = false}
+rstest = { version = "0.26.1", default-features = false }
+tempfile = { version = "3.23.0", default-features = false }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ editor written by Salvatore Sanfilippo (antirez) in C, and
 * *Save as* prompt when no file name has been provided
 * Command to duplicate the current row, to quickly move between words
 * Ability to execute an external command from the editor and paste its output
+* Support for end-of-options delimiter `--` (following [POSIX.1-2024 12. Utility Conventions](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html))
+* Can be used as the editor for the *`sudoers`* file via [`visudo`](https://www.man7.org/linux/man-pages/man8/visudo.8.html)
 * Guaranteed memory safety, thanks to Rust!
 * Bug fixes
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -696,8 +696,8 @@ impl Editor {
     /// # Errors
     ///
     /// Will Return `Err` if any error occur.
-    pub fn run(&mut self, file_name: &Option<String>) -> Result<(), Error> {
-        if let Some(path) = file_name.as_ref().map(|p| sys::path(p.as_str())) {
+    pub fn run(&mut self, file_name: Option<&str>) -> Result<(), Error> {
+        if let Some(path) = file_name.map(sys::path) {
             self.syntax = SyntaxConf::find(&path.to_string_lossy(), &sys::data_dirs());
             self.load(path.as_path())?;
             self.file_name = Some(path.to_string_lossy().to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,10 +11,11 @@ use kibi::{Config, Editor, Error};
 /// this function.
 fn main() -> Result<(), Error> {
     let mut args = std::env::args();
-    match (args.nth(1), /* remaining_args= */ args.len()) {
-        (Some(arg), 0) if arg == "--version" => println!("kibi {}", env!("KIBI_VERSION")),
-        (Some(arg), 0) if arg.starts_with('-') => return Err(Error::UnrecognizedOption(arg)),
-        (file_name, 0) => Editor::new(Config::load())?.run(&file_name)?,
+    match (args.nth(1).as_deref(), args.next().as_deref(), /* remaining_args= */ args.len()) {
+        (Some("--version"), None | Some("--"), 0) => println!("kibi {}", env!("KIBI_VERSION")),
+        (Some(o), ..) if o.starts_with('-') && o != "--" =>
+            return Err(Error::UnrecognizedOption(o.into())),
+        (Some("--"), p, 0) | (p, Some("--") | None, 0) => Editor::new(Config::load())?.run(p)?,
         _ => return Err(Error::TooManyArguments(std::env::args().collect())),
     }
     Ok(())


### PR DESCRIPTION
Fixes #474 #476

Can be now used with `visudo`: tested with `SUDO_EDITOR=target/debug/kibi sudo visudo`