### PR TITLE
Replace feature

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -801,8 +801,9 @@ impl PromptMode {
                             Some(m) => Some(Self::Replace(search_query, replace_text, saved_cursor, Some(m), ReplaceMode::Interactive)),
                             None => { set_status!(ed, "No more matches"); None }
                         },
-                        Key::Char(b'a' | b'A') => { let mut count = 0;
-                            while ed.find(&search_query, last_match, true).is_some() { ed.replace_current_match(&search_query, &replace_text); count += 1; }
+                        Key::Char(b'a' | b'A') => { let mut count = 0; let mut last = last_match;
+                            while let Some(m) = ed.find(&search_query, last, true) { ed.replace_current_match(&search_query, &replace_text); count += 1; last = Some(m); }
+                            if let Some(row_idx) = last { ed.rows[row_idx].match_segment = None; }
                             set_status!(ed, "Replaced {count} occurrence(s)"); None }
                         Key::Char(b'q' | b'Q') | Key::Escape => { set_status!(ed, "Replace cancelled"); None }
                         _ => Some(Self::Replace(search_query, replace_text, saved_cursor, last_match, ReplaceMode::Interactive)),


### PR DESCRIPTION
## Add Find and Replace Feature

Implementation of a comprehensive find and replace feature for Kibi, allowing users to search for text and replace it interactively or all at once.

### Features

- **Find Mode** (`Ctrl+F`): Search for text with forward/backward navigation
- **Replace Mode** (`Ctrl+R`): Search and replace with multiple options:
  - **Interactive Replace**: Review each match individually
    - `y/Y`: Replace current match and move to next
    - `n/N`: Skip current match and move to next
    - `a/A`: Replace all remaining matches
    - `q/Q` or `Esc`: Cancel and exit
  - **Seamless Transition**: Switch from Find to Replace mode by pressing `Ctrl+R` during search

### Implementation Details

- Matches are highlighted in real-time during search
- Cursor position is saved and can be restored on cancellation
- Efficient search algorithm that supports both forward and backward traversal
- Clean highlight cleanup when exiting prompts
- All functionality implemented with compact, optimized code to maintain codebase size under 1024 lines (excluding comments)

### User Experience

1. Press `Ctrl+F` to start searching
2. Type search query and navigate matches with arrow keys or repeated `Ctrl+F`
3. Press `Ctrl+R` to switch to replace mode
4. Enter replacement text
5. Choose to replace interactively or all at once

### Code Quality

- Maintains existing code style and conventions
- Preserves all comments and documentation
- Zero impact on existing features
- Compiles cleanly with no warnings or errors