### PR TITLE
Simplifies /src/row.rs : 'update()' method implementation

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -186,9 +186,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"

--- a/src/row.rs
+++ b/src/row.rs
@@ -61,7 +61,7 @@ impl Row {
     /// Update the row: convert tabs into spaces and compute highlight symbols
     /// The `hl_state` argument is the `HLState` for the previous row.
     pub fn update(&mut self, syntax: &SyntaxConf, hl_state: HlState, tab: NonZeroUsize) -> HlState {
-        self.render.clear(); self.cx2rx.clear(); self.rx2cx.clear(); //Aligned to keep a minimal ammount on lines
+        self.render.clear(); self.cx2rx.clear(); self.rx2cx.clear(); //Compact to keep the file under the line limit
         let mut cx = 0; let mut rx = 0;
 
         for c in String::from_utf8_lossy(&self.chars).chars() {

--- a/src/row.rs
+++ b/src/row.rs
@@ -61,18 +61,19 @@ impl Row {
     /// Update the row: convert tabs into spaces and compute highlight symbols
     /// The `hl_state` argument is the `HLState` for the previous row.
     pub fn update(&mut self, syntax: &SyntaxConf, hl_state: HlState, tab: NonZeroUsize) -> HlState {
-        let (..) = (self.render.clear(), self.cx2rx.clear(), self.rx2cx.clear());
-        let (mut cx, mut rx) = (0, 0);
+        self.render.clear(); self.cx2rx.clear(); self.rx2cx.clear(); //Aligned to keep a minimal ammount on lines
+        let mut cx = 0; let mut rx = 0;
+
         for c in String::from_utf8_lossy(&self.chars).chars() {
             // The number of rendered characters
             let n_rend_chars =
                 if c == '\t' { tab.get() - (rx % tab) } else { c.width().unwrap_or(1) };
-            self.render.push_str(&(if c == '\t' { " ".repeat(n_rend_chars) } else { c.into() }));
+            if c == '\t' { self.render.push_str(&" ".repeat(n_rend_chars)); } else { self.render.push(c); }
             self.cx2rx.extend(repeat_n(rx, c.len_utf8()));
             self.rx2cx.extend(repeat_n(cx, n_rend_chars));
-            (rx, cx) = (rx + n_rend_chars, cx + c.len_utf8());
+            rx += n_rend_chars; cx += c.len_utf8();
         }
-        let (..) = (self.cx2rx.push(rx), self.rx2cx.push(cx));
+        self.cx2rx.push(rx); self.rx2cx.push(cx);   
         self.update_syntax(syntax, hl_state)
     }
 


### PR DESCRIPTION
# Simplify the `update()` method

Improves readability and removes an unnecessary allocation in the `update()` method.

Changes:

- Replaced tuple-based side-effect expressions (`let (..) = (...)`) with direct method calls (`self.render.clear()`, etc.).
- Removed `c.into()` and used `push()` for non-tab characters, avoiding the creation of a temporary `String`.
- Replaced `(rx, cx) = (...)` with `rx += ...; cx += ...;`, which is more idiomatic and easier to read.

No functional changes intended.
